### PR TITLE
To not bug out on MTL files with transparency

### DIFF
--- a/pywavefront/material.py
+++ b/pywavefront/material.py
@@ -150,6 +150,10 @@ class MaterialParser(parser.Parser):
         # unimplemented
         return
 
+    def parse_Tr(self, args):
+        # unimplemented
+        return
+
     def parse_illum(self, args):
         # unimplemented
         return


### PR DESCRIPTION
Required to parse some MTL files with transparency variable.