### PR TITLE
Handle any unimplemented flag and carry on with a warning

### DIFF
--- a/pywavefront/__init__.py
+++ b/pywavefront/__init__.py
@@ -147,7 +147,3 @@ class ObjParser(parser.Parser):
             if i == 0:
                 v1 = vertex
             vlast = vertex
-
-    def parse_s(self, args):
-        # unimplemented
-        return

--- a/pywavefront/parser.py
+++ b/pywavefront/parser.py
@@ -63,5 +63,11 @@ class Parser(object):
                 args[i] = arg
             i += 1
 
-        parse_function = getattr(self, 'parse_%s' % line_type)
-        parse_function(args)
+        attrib = 'parse_%s' % line_type
+
+        if hasattr(self, attrib):
+            parse_function = getattr(self, attrib)
+            parse_function(args)
+        else:
+            print("[PyWavefront] WARNING: Unimplemented OBJ format statement \'%s\' on line \'%s\'"
+                  % (line_type, line.rstrip()))


### PR DESCRIPTION
Some statements like 'g grpl' were causing the import process to throw. This simple fix allows it to carry on with a warning, and removes the need to add explicit 'parse_x' functions with '#unimplemented' back on the main __init__.py

This can be used for materials too. 

Eventually we can add a debug layer instead of this print statement.