### PR TITLE
Use the correct accented "é" character

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Contributors
 * Jerek Shoemaker
 * Kurt Yoder
 * Marxlp
-* Sérgio Agostinho
+* Sérgio Agostinho
 * Zohar Jackson
 
 License


### PR DESCRIPTION
The previous one has a weird encoding which causes a `UnicodeDecodeError:`. This change replaces it with a regular accented e ("é"), which does not produce a unicode error.