### PR TITLE
Specify the full path for the test files. Removed pyglet dep on unit tests

### DIFF
--- a/test/test_material.py
+++ b/test/test_material.py
@@ -3,12 +3,14 @@ import os
 
 import pywavefront.material
 
+def prepend_dir(file):
+    return os.path.join(os.path.dirname(__file__), file)
+
 class TestMaterial(unittest.TestCase):
     def setUp(self):
         # Append current path to locate files
-        folder = os.path.dirname(__file__) + '/'
-        self.material = pywavefront.material.Material(folder + 'material')
-        self.material.set_texture(folder + '4x4.png')
+        self.material = pywavefront.material.Material(prepend_dir('material'))
+        self.material.set_texture(prepend_dir('4x4.png'))
 
     def testSetTexture(self):
         "Running set_texture should set a texture."

--- a/test/test_material.py
+++ b/test/test_material.py
@@ -1,15 +1,14 @@
 import unittest
-
-import pyglet
+import os
 
 import pywavefront.material
 
 class TestMaterial(unittest.TestCase):
     def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
-        self.material = pywavefront.material.Material('material')
-        self.material.set_texture('4x4.png')
+        # Append current path to locate files
+        folder = os.path.dirname(__file__) + '/'
+        self.material = pywavefront.material.Material(folder + 'material')
+        self.material.set_texture(folder + '4x4.png')
 
     def testSetTexture(self):
         "Running set_texture should set a texture."
@@ -55,9 +54,6 @@ class TestMaterial(unittest.TestCase):
         self.assertEqual(self.material.emissive, [0., 0., 0., 0.])
 
 class TestInvalidMaterial(unittest.TestCase):
-    def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
 
     def testSetInvalidTexture(self):
         "Running set_texture with a nonexistent file should raise an exception."

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -1,13 +1,8 @@
 import unittest
 
-import pyglet
-
 import pywavefront.mesh
 
 class TestMesh(unittest.TestCase):
-    def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
 
     def testMeshName(self):
         "Creating a mesh with a name should set the name."

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,14 +1,13 @@
 import unittest
-
-import pyglet
+import os
 
 import pywavefront.parser
 
 class TestParsers(unittest.TestCase):
     def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
-        meshes = pywavefront.Wavefront('simple.obj')
+        # Append current path to locate files
+        folder = os.path.dirname(__file__) + '/'
+        meshes = pywavefront.Wavefront(folder + 'simple.obj')
         self.mesh1 = meshes.mesh_list[0]
         self.mesh2 = meshes.mesh_list[1]
 
@@ -37,9 +36,9 @@ class TestParsers(unittest.TestCase):
 
 class TestMtlParser(unittest.TestCase):
     def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
-        meshes = pywavefront.Wavefront('simple.obj')
+        # Append current path to locate files
+        self.folder = os.path.dirname(__file__) + '/'
+        meshes = pywavefront.Wavefront(self.folder + 'simple.obj')
         self.material1 = meshes.mesh_list[0].materials[0]
         self.material2 = meshes.mesh_list[1].materials[0]
 
@@ -70,17 +69,18 @@ class TestMtlParser(unittest.TestCase):
     def testMtlTextureName(self):
         "Parsing an obj file with known material texture should set its name."
         # also tests d
-        self.assertEqual(self.material1.texture.image_name, '4x4.png')
+        self.assertEqual(self.material1.texture.image_name,
+                         self.folder + '4x4.png')
 
 class TestParserFailure(unittest.TestCase):
     def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
+        # Append current path to locate files
+        self.folder = os.path.dirname(__file__) + '/'
 
     def testMissingParseFunction(self):
         "Attempting to parse with a missing parse function should raise an exception."
         # since no parse functions have been defined, this will always fail
-        self.assertRaises(Exception, pywavefront.parser.Parser, 'uv_sphere.obj')
+        self.assertRaises(Exception, pywavefront.parser.Parser, self.folder + 'uv_sphere.obj')
 
     def testMissingParsedFile(self):
         "Referencing a missing parsed file should raise an exception."

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -3,11 +3,13 @@ import os
 
 import pywavefront.parser
 
+def prepend_dir(file):
+    return os.path.join(os.path.dirname(__file__), file)
+
 class TestParsers(unittest.TestCase):
     def setUp(self):
         # Append current path to locate files
-        folder = os.path.dirname(__file__) + '/'
-        meshes = pywavefront.Wavefront(folder + 'simple.obj')
+        meshes = pywavefront.Wavefront(prepend_dir('simple.obj'))
         self.mesh1 = meshes.mesh_list[0]
         self.mesh2 = meshes.mesh_list[1]
 
@@ -37,8 +39,7 @@ class TestParsers(unittest.TestCase):
 class TestMtlParser(unittest.TestCase):
     def setUp(self):
         # Append current path to locate files
-        self.folder = os.path.dirname(__file__) + '/'
-        meshes = pywavefront.Wavefront(self.folder + 'simple.obj')
+        meshes = pywavefront.Wavefront(prepend_dir('simple.obj'))
         self.material1 = meshes.mesh_list[0].materials[0]
         self.material2 = meshes.mesh_list[1].materials[0]
 
@@ -70,17 +71,14 @@ class TestMtlParser(unittest.TestCase):
         "Parsing an obj file with known material texture should set its name."
         # also tests d
         self.assertEqual(self.material1.texture.image_name,
-                         self.folder + '4x4.png')
+                         prepend_dir('4x4.png'))
 
 class TestParserFailure(unittest.TestCase):
-    def setUp(self):
-        # Append current path to locate files
-        self.folder = os.path.dirname(__file__) + '/'
 
     def testMissingParseFunction(self):
         "Attempting to parse with a missing parse function should raise an exception."
         # since no parse functions have been defined, this will always fail
-        self.assertRaises(Exception, pywavefront.parser.Parser, self.folder + 'uv_sphere.obj')
+        self.assertRaises(Exception, pywavefront.parser.Parser, prepend_dir('uv_sphere.obj'))
 
     def testMissingParsedFile(self):
         "Referencing a missing parsed file should raise an exception."

--- a/test/test_texture.py
+++ b/test/test_texture.py
@@ -3,18 +3,19 @@ import os
 
 import pywavefront.texture
 
+def prepend_dir(file):
+    return os.path.join(os.path.dirname(__file__), file)
+
 class TestTexture(unittest.TestCase):
-    def setUp(self):
-        self.folder = os.path.dirname(__file__) + '/'
 
     def testPathedImageName(self):
         "For Texture objects, the image name should be the last component of the path."
-        my_texture = pywavefront.texture.Texture(self.folder + '4x4.png')
-        self.assertEqual(my_texture.image_name, self.folder + '4x4.png')
+        my_texture = pywavefront.texture.Texture(prepend_dir('4x4.png'))
+        self.assertEqual(my_texture.image_name, prepend_dir('4x4.png'))
 
     def testNonPowerOfTwoImage(self):
         "Texture images that have a non-power-of-two dimension should raise an exception."
-        self.assertRaises(Exception, pywavefront.texture.Texture, self.folder + '3x4.png')
+        self.assertRaises(Exception, pywavefront.texture.Texture, prepend_dir('3x4.png'))
 
     def testMissingFile(self):
         "Referencing a missing texture file should raise an exception."

--- a/test/test_texture.py
+++ b/test/test_texture.py
@@ -1,22 +1,20 @@
 import unittest
-
-import pyglet
+import os
 
 import pywavefront.texture
 
 class TestTexture(unittest.TestCase):
     def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
+        self.folder = os.path.dirname(__file__) + '/'
 
     def testPathedImageName(self):
         "For Texture objects, the image name should be the last component of the path."
-        my_texture = pywavefront.texture.Texture('4x4.png')
-        self.assertEqual(my_texture.image_name, '4x4.png')
+        my_texture = pywavefront.texture.Texture(self.folder + '4x4.png')
+        self.assertEqual(my_texture.image_name, self.folder + '4x4.png')
 
     def testNonPowerOfTwoImage(self):
         "Texture images that have a non-power-of-two dimension should raise an exception."
-        self.assertRaises(Exception, pywavefront.texture.Texture, '3x4.png')
+        self.assertRaises(Exception, pywavefront.texture.Texture, self.folder + '3x4.png')
 
     def testMissingFile(self):
         "Referencing a missing texture file should raise an exception."

--- a/test/test_wavefront.py
+++ b/test/test_wavefront.py
@@ -1,16 +1,14 @@
 import unittest
-
-import pyglet
+import os
 
 import pywavefront
 
 class TestWavefront(unittest.TestCase):
     def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
+        folder = os.path.dirname(__file__) + '/'
         self.mesh_names = ['Simple', 'SimpleB']
         self.material_names = ['Material.simple', 'Material2.simple']
-        self.meshes = pywavefront.Wavefront('simple.obj')
+        self.meshes = pywavefront.Wavefront(folder + 'simple.obj')
 
     def testMaterials(self):
         "Ensure parsed wavefront materials match known values."
@@ -42,27 +40,25 @@ class TestWavefront(unittest.TestCase):
 
 class TestBrokenWavefront(unittest.TestCase):
     def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
+        self.folder = os.path.dirname(__file__) + '/'
 
     def testUnknownUsemtl(self):
         "Referencing an unknown material with usemtl should raise an exception."
         self.assertRaises(pywavefront.PywavefrontException,
-                pywavefront.Wavefront, 'simple_unknown_usemtl.obj')
+                pywavefront.Wavefront, self.folder + 'simple_unknown_usemtl.obj')
 
     def testMissingNormals(self):
         "If there are texture coordinates but no normals, should raise an exception."
         self.assertRaises(pywavefront.PywavefrontException,
-                pywavefront.Wavefront, 'simple_missing_normals.obj')
+                pywavefront.Wavefront, self.folder + 'simple_missing_normals.obj')
 
 class TestNoMaterial(TestWavefront):
     def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
+        folder = os.path.dirname(__file__) + '/'
         # reset the obj file to new file with no mtl line
         self.mesh_names = ['Simple', 'SimpleB']
         self.material_names = [None]
-        self.meshes = pywavefront.Wavefront('simple_no_mtl.obj')
+        self.meshes = pywavefront.Wavefront(folder + 'simple_no_mtl.obj')
 
     def testMeshMaterialVertices(self):
         "Mesh vertices should have known values."
@@ -70,9 +66,9 @@ class TestNoMaterial(TestWavefront):
 
 class TestNoObjectNoMaterial(TestNoMaterial):
     def setUp(self):
-        pyglet.resource.path.append('@' + __name__)
-        pyglet.resource.reindex()
+        folder = os.path.dirname(__file__) + '/'
+
         # reset the obj file to new file with no mtl line
         self.mesh_names = [None]
         self.material_names = [None]
-        self.meshes = pywavefront.Wavefront('simple_no_object_no_mtl.obj')
+        self.meshes = pywavefront.Wavefront(folder + 'simple_no_object_no_mtl.obj')

--- a/test/test_wavefront.py
+++ b/test/test_wavefront.py
@@ -3,12 +3,14 @@ import os
 
 import pywavefront
 
+def prepend_dir(file):
+    return os.path.join(os.path.dirname(__file__), file)
+
 class TestWavefront(unittest.TestCase):
     def setUp(self):
-        folder = os.path.dirname(__file__) + '/'
         self.mesh_names = ['Simple', 'SimpleB']
         self.material_names = ['Material.simple', 'Material2.simple']
-        self.meshes = pywavefront.Wavefront(folder + 'simple.obj')
+        self.meshes = pywavefront.Wavefront(prepend_dir('simple.obj'))
 
     def testMaterials(self):
         "Ensure parsed wavefront materials match known values."
@@ -39,26 +41,23 @@ class TestWavefront(unittest.TestCase):
         self.assertEqual(len(self.meshes.meshes[self.mesh_names[0]].materials[0].vertices), 24)
 
 class TestBrokenWavefront(unittest.TestCase):
-    def setUp(self):
-        self.folder = os.path.dirname(__file__) + '/'
 
     def testUnknownUsemtl(self):
         "Referencing an unknown material with usemtl should raise an exception."
         self.assertRaises(pywavefront.PywavefrontException,
-                pywavefront.Wavefront, self.folder + 'simple_unknown_usemtl.obj')
+                pywavefront.Wavefront, prepend_dir('simple_unknown_usemtl.obj'))
 
     def testMissingNormals(self):
         "If there are texture coordinates but no normals, should raise an exception."
         self.assertRaises(pywavefront.PywavefrontException,
-                pywavefront.Wavefront, self.folder + 'simple_missing_normals.obj')
+                pywavefront.Wavefront, prepend_dir('simple_missing_normals.obj'))
 
 class TestNoMaterial(TestWavefront):
     def setUp(self):
-        folder = os.path.dirname(__file__) + '/'
         # reset the obj file to new file with no mtl line
         self.mesh_names = ['Simple', 'SimpleB']
         self.material_names = [None]
-        self.meshes = pywavefront.Wavefront(folder + 'simple_no_mtl.obj')
+        self.meshes = pywavefront.Wavefront(prepend_dir('simple_no_mtl.obj'))
 
     def testMeshMaterialVertices(self):
         "Mesh vertices should have known values."
@@ -66,9 +65,7 @@ class TestNoMaterial(TestWavefront):
 
 class TestNoObjectNoMaterial(TestNoMaterial):
     def setUp(self):
-        folder = os.path.dirname(__file__) + '/'
-
         # reset the obj file to new file with no mtl line
         self.mesh_names = [None]
         self.material_names = [None]
-        self.meshes = pywavefront.Wavefront(folder + 'simple_no_object_no_mtl.obj')
+        self.meshes = pywavefront.Wavefront(prepend_dir('simple_no_object_no_mtl.obj'))


### PR DESCRIPTION
I'm not sure about other platforms, but most unit tests were failing for me with FileNotFound errors. By specifying the full path to files, I was able to remove the explicit `pyglet` dependency from the test files.

I intend to build upon this and try to isolate pyglet specific code from the rest in a follow up pull request.
