### PR TITLE
Use setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 VERSION = '0.2.0'
 


### PR DESCRIPTION
As recommended by on python.org https://packaging.python.org/guides/tool-recommendations/
Better build support such as `develop` and `bdist_wheel`.

In local development I can't for example install the package with `python setup.py develop`

Also building the package with `bdist_wheel` instead of `sdist` is a lot more common these days. (distributing a `.whl` file instead of `tar.gz`)