### PR TITLE
Visualization should cap shinyness

### DIFF
--- a/pywavefront/visualization.py
+++ b/pywavefront/visualization.py
@@ -96,7 +96,7 @@ def draw_material(material, face=GL_FRONT_AND_BACK):
     glMaterialfv(face, GL_AMBIENT, gl_light(material.ambient))
     glMaterialfv(face, GL_SPECULAR, gl_light(material.specular))
     glMaterialfv(face, GL_EMISSION, gl_light(material.emissive))
-    glMaterialf(face, GL_SHININESS, material.shininess)
+    glMaterialf(face, GL_SHININESS, min(128.0, material.shininess))
     glEnable(GL_LIGHT0)
 
     if material.has_normals:


### PR DESCRIPTION
wavefront supports 1-1000 range for shinyness. while `GL_SHININESS` is capped to 128.0. Some drivers are not happy when > 128.0 values are used.

Fixes #44

We fix this in the `visualization` module itself. Not in the material class since we should not mess with the raw value.