### PR TITLE
Various bug fixes

### DIFF
--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -178,9 +178,6 @@ class ObjParser(Parser):
         has_vn = False
         has_colors = False
 
-        # If the face contains elements
-        triangulate = len(self.values) - 1 >= 4
-
         parts = self.values[1].split('/')
         # We assume texture coordinates are present
         if len(parts) == 2:
@@ -215,6 +212,9 @@ class ObjParser(Parser):
         # The loop continues until there are no more f-statements or StopIteration is raised by generator
         while True:
             v1, vlast = None, None
+
+            # Do we need to triangulate? Each line may contain a varying amount of elements
+            triangulate = (len(self.values) - 1) > 3
 
             for i, v in enumerate(self.values[1:]):
                 parts = v.split('/')

--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -62,7 +62,10 @@ class ObjParser(Parser):
                 )
 
             self.next_line()
-            if self.values[0] != "v":
+            if not self.values:
+                break
+
+            if self.values and self.values[0] != "v":
                 break
 
     def parse_vn(self):
@@ -70,7 +73,7 @@ class ObjParser(Parser):
 
         # Since list() also consumes StopIteration we need to sanity check the line
         # to make sure the parser advances
-        if self.values[0] == "vn":
+        if self.values and self.values[0] == "vn":
             self.next_line()
 
     def consume_normals(self):
@@ -85,6 +88,9 @@ class ObjParser(Parser):
             )
 
             self.next_line()
+            if not self.values:
+                break
+
             if self.values[0] != "vn":
                 break
 
@@ -107,6 +113,9 @@ class ObjParser(Parser):
             )
 
             self.next_line()
+            if not self.values:
+                break
+
             if self.values[0] != "vt":
                 break
 
@@ -154,7 +163,7 @@ class ObjParser(Parser):
 
         # Since list() also consumes StopIteration we need to sanity check the line
         # to make sure the parser advances
-        if self.values[0] == "f":
+        if self.values and self.values[0] == "f":
             self.next_line()
 
     def consume_faces(self):
@@ -269,5 +278,8 @@ class ObjParser(Parser):
 
             # Break out of the loop when there are no more f statements
             self.next_line()
+            if not self.values:
+                break
+
             if self.values[0] != "f":
                 break

--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -200,7 +200,7 @@ class ObjParser(Parser):
             has_vn = True
 
         # Are we referencing vertex with color info?
-        vertex = self.vertices[int(parts[0])]
+        vertex = self.vertices[int(parts[0]) - 1]
         has_colors = len(vertex) == 6
 
         # Prepare vertex format string

--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -65,7 +65,7 @@ class ObjParser(Parser):
             if not self.values:
                 break
 
-            if self.values and self.values[0] != "v":
+            if self.values[0] != "v":
                 break
 
     def parse_vn(self):

--- a/pywavefront/parser.py
+++ b/pywavefront/parser.py
@@ -82,8 +82,6 @@ class Parser(object):
                 gz = gzip.open(self.file_name, mode='rt')
 
             for line in gz.readlines():
-                if line == '':
-                    continue
                 yield line
 
             gz.close()
@@ -96,8 +94,6 @@ class Parser(object):
                 file = codecs.open(self.file_name, mode='r', encoding=self.encoding)
 
             for line in file:
-                if line == '':  # Skip empty lines
-                    continue
                 yield line
 
             file.close()


### PR DESCRIPTION
- Some obj files have a varying amount of elements per `f` line. Move triangulate check inside the loop
- More rebust checking of empty lines in functions consuming multiple lines
- Offset bug when checking vertex format
- Don't care about yielding empty lines in line generator. Lines contain a newline anyway