### PR TITLE
Parser can create missing materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ A more complex example
 
 * `strict` will raise an exception if unsupported features are found in the obj or mtl file. Default `True`.
 * `encoding` of the obj and mtl file(s). Default `utf-8`.
-* `parse` decides if parsing should start immediately. Default 'False'.
+* `create_materials` will create materials if mtl file is missing or obj file references non-exiting materials . Default `False`.
+* `parse` decides if parsing should start immediately. Default `False`.
 
 ```python
 import pywavefront

--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -142,7 +142,7 @@ class ObjParser(Parser):
         if self.material is None:
             # Create a new default material if configured to resolve missing ones
             if self.create_materials:
-                self.material = Material()
+                self.material = Material(name=name, is_default=True)
                 self.wavefront.materials[name] = self.material
             else:
                 raise PywavefrontException('Unknown material: %s' % name)
@@ -226,7 +226,10 @@ class ObjParser(Parser):
 
         # If the material already have vertex data, ensure the same format is used
         if self.material.vertex_format and self.material.vertex_format != vertex_format:
-            raise ValueError("Trying to merge vertex data with different formats")
+            raise ValueError((
+                "Trying to merge vertex data with different format: {}. "
+                "Material {} has vertex format {}"
+            ).format(vertex_format, self.material.name, self.material.vertex_format))
 
         self.material.vertex_format = vertex_format
 

--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -140,12 +140,12 @@ class ObjParser(Parser):
         self.material = self.wavefront.materials.get(name, None)
 
         if self.material is None:
-            # Create a new default material if configured to resolve missing ones
-            if self.create_materials:
-                self.material = Material(name=name, is_default=True)
-                self.wavefront.materials[name] = self.material
-            else:
+            if not self.create_materials:
                 raise PywavefrontException('Unknown material: %s' % name)
+
+            # Create a new default material if configured to resolve missing ones
+            self.material = Material(name=name, is_default=True)
+            self.wavefront.materials[name] = self.material
 
         if self.mesh is not None:
             self.mesh.add_material(self.material)

--- a/pywavefront/wavefront.py
+++ b/pywavefront/wavefront.py
@@ -6,11 +6,13 @@ class Wavefront(object):
     parser_cls = ObjParser
 
     """Import a wavefront .obj file."""
-    def __init__(self, file_name, strict=False, encoding="utf-8", parse=True):
+    def __init__(self, file_name, strict=False, encoding="utf-8", create_materials=False, parse=True):
         """
         Create a Wavefront instance
         :param file_name: file name and path of obj file to read
         :param strict: Enable strict mode
+        :param encoding: What text encoding the parser should use
+        :param create_materials: Create materials if they don't exist
         :param parse: Should parse be called immediately or manually called later?
         """
         self.file_name = file_name
@@ -19,7 +21,13 @@ class Wavefront(object):
         self.meshes = {}        # Name mapping
         self.mesh_list = []     # Also includes anonymous meshes
 
-        self.parser = self.parser_cls(self, self.file_name, strict=strict, encoding=encoding, parse=parse)
+        self.parser = self.parser_cls(
+            self,
+            self.file_name,
+            strict=strict,
+            encoding=encoding,
+            create_materials=create_materials,
+            parse=parse)
 
     def parse(self):
         """Manually call the parser. This is used when parse=False"""

--- a/test/simple_missing_material.obj
+++ b/test/simple_missing_material.obj
@@ -1,0 +1,26 @@
+# Comment
+mtllib simple_missing.mtl
+o Simple
+v 0.01 0.02 0.03
+v 0.04 0.05 0.06
+v 0.07 0.08 0.09
+v 0.11 0.12 0.13
+vt 10 11
+vt 12 13
+vt 14 15
+vt 16 17
+vn 20 21 22
+usemtl Material.simple
+f 2/3/1 1/2/1 3/1/1
+o SimpleB
+v 1.0 0.0 1.0
+v -1.0 0.0 1.0
+v 1.0 0.0 -1.0
+v -1.0 0.0 -1.0
+vt 0.0 1.0
+vt 0.0 0.0
+vt 1.0 0.0
+vt 1.0 1.0
+vn 0.0 1.0 -0.0
+usemtl Material2.simple
+f 6/7/2 5/6/2 7/5/2

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -54,6 +54,19 @@ class TestParserGz(TestParsers):
         self.mesh2 = meshes.mesh_list[1]
 
 
+class TestParserMissingMaterials(unittest.TestCase):
+    """Test `create_materials` functionality"""
+
+    def test_missing_material_error(self):
+        """Parser should crash if `create_materials` is not set"""
+        with self.assertRaises(IOError):
+            pywavefront.Wavefront(prepend_dir('simple_missing_material.obj'))
+
+    def test_missing_material_create(self):
+        """Parser should handle missing materials if `create_materials` is set"""
+        pywavefront.Wavefront(prepend_dir('simple_missing_material.obj'), create_materials=True)
+
+
 class TestParserVertexVariants(unittest.TestCase):
 
     def testObjNoNormals(self):


### PR DESCRIPTION
Add an option allowing the parser to auto create missing materials. This supports missing mtl files and references to material names that doesn't exist