### PR TITLE
Allow users to override material parser

### DIFF
--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -8,6 +8,7 @@ from pywavefront.mesh import Mesh
 
 class ObjParser(Parser):
     """This parser parses lines from .obj files."""
+    material_parser_cls = MaterialParser
 
     def __init__(self, wavefront, file_name, strict=False, encoding="utf-8", parse=True):
         """
@@ -122,7 +123,7 @@ class ObjParser(Parser):
     @auto_consume
     def parse_mtllib(self):
         mtllib = os.path.join(self.dir, " ".join(self.values[1:]))
-        materials = MaterialParser(mtllib, encoding=self.encoding, strict=self.strict).materials
+        materials = self.material_parser_cls(mtllib, encoding=self.encoding, strict=self.strict).materials
 
         for name, material in materials.items():
             self.wavefront.materials[name] = material


### PR DESCRIPTION
We should allow users to override the material parser. They can simply make a subclass of the obj parser.

```python
class CustomObjParser(ObjParser):
    material_parser_cls = CustomMaterialParser

class CustomWavefront(Wafefront):
    parser_cls = CustomObjParser

scene = CustomWavefront(...)
```

This is a lot less hassle than overriding methods possibly breaking forward compatibility.