### PR TITLE
Texture loading improvements

### DIFF
--- a/pywavefront/texture.py
+++ b/pywavefront/texture.py
@@ -31,15 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
-import os
-
-from pywavefront.exceptions import PywavefrontException
 
 
 class Texture(object):
     def __init__(self, path):
-        self.image_name = path
+        # Treat path as part of a file uri always using forward slashes
+        self.path = path.replace('\\', '/')
         self.image = None
-
-        if not os.path.exists(path):
-            raise PywavefrontException("Requested file does not exist")

--- a/pywavefront/texture.py
+++ b/pywavefront/texture.py
@@ -38,3 +38,8 @@ class Texture(object):
         # Treat path as part of a file uri always using forward slashes
         self.path = path.replace('\\', '/')
         self.image = None
+
+    @property
+    def image_name(self):
+        """Wrap the old property name to not break compatibility"""
+        return self.path

--- a/pywavefront/texture.py
+++ b/pywavefront/texture.py
@@ -31,15 +31,24 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
+import os
 
 
 class Texture(object):
     def __init__(self, path):
         # Treat path as part of a file uri always using forward slashes
-        self.path = path.replace('\\', '/')
+        self.path = path.replace('\\', os.path.sep)
         self.image = None
 
     @property
     def image_name(self):
         """Wrap the old property name to not break compatibility"""
         return self.path
+
+    @image_name.setter
+    def image_name(self, value):
+        """Wrap the old property name to not break compatibility"""
+        self.path = value
+
+    def exists(self):
+        return os.path.exists(self.path)

--- a/pywavefront/visualization.py
+++ b/pywavefront/visualization.py
@@ -119,7 +119,7 @@ def gl_light(lighting):
 def bind_texture(texture):
     """Draw a single texture"""
     if not getattr(texture, 'image', None):
-        texture.image = load_image(texture.image_name)
+        texture.image = load_image(texture.path)
 
     glEnable(texture.image.target)
     glBindTexture(texture.image.target, texture.image.id)

--- a/test/test_material.py
+++ b/test/test_material.py
@@ -56,11 +56,3 @@ class TestMaterial(unittest.TestCase):
         """set_emissive should set known values."""
         self.material.set_emissive()
         self.assertEqual(self.material.emissive, [0., 0., 0., 0.])
-
-
-class TestInvalidMaterial(unittest.TestCase):
-
-    def testSetInvalidTexture(self):
-        """Running set_texture with a nonexistent file should raise an exception."""
-        material = pywavefront.material.Material('material')
-        self.assertRaises(Exception, material.set_texture, 'missing.file.do.not.create')

--- a/test/test_material.py
+++ b/test/test_material.py
@@ -56,3 +56,12 @@ class TestMaterial(unittest.TestCase):
         """set_emissive should set known values."""
         self.material.set_emissive()
         self.assertEqual(self.material.emissive, [0., 0., 0., 0.])
+
+
+class TestInvalidMaterial(unittest.TestCase):
+
+    def test_missing_texture(self):
+        """Running set_texture with a nonexistent file should raise an exception."""
+        material = pywavefront.material.Material('material')
+        material.set_texture('missing.file.do.not.create')
+        self.assertFalse(material.texture.exists())

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -175,7 +175,7 @@ class TestMtlParser(unittest.TestCase):
     def testMtlTextureName(self):
         """Parsing an obj file with known material texture should set its name."""
         # also tests d
-        self.assertEqual(self.material1.texture.image_name,
+        self.assertEqual(self.material1.texture.path,
                          prepend_dir('4x4.png'))
 
 

--- a/test/test_texture.py
+++ b/test/test_texture.py
@@ -13,8 +13,4 @@ class TestTexture(unittest.TestCase):
     def testPathedImageName(self):
         """For Texture objects, the image name should be the last component of the path."""
         my_texture = pywavefront.texture.Texture(prepend_dir('4x4.png'))
-        self.assertEqual(my_texture.image_name, prepend_dir('4x4.png'))
-
-    def testMissingFile(self):
-        """Referencing a missing texture file should raise an exception."""
-        self.assertRaises(Exception, pywavefront.texture.Texture, 'missing.file.do.not.create')
+        self.assertEqual(my_texture.path, prepend_dir('4x4.png'))

--- a/test/test_texture.py
+++ b/test/test_texture.py
@@ -14,3 +14,8 @@ class TestTexture(unittest.TestCase):
         """For Texture objects, the image name should be the last component of the path."""
         my_texture = pywavefront.texture.Texture(prepend_dir('4x4.png'))
         self.assertEqual(my_texture.path, prepend_dir('4x4.png'))
+
+    def testMissingFile(self):
+        """Referencing a missing texture file should raise an exception."""
+        texture = pywavefront.texture.Texture('missing.file.do.not.create')
+        self.assertFalse(texture.exists())


### PR DESCRIPTION
- Skip early exist check of the texture. A program might want modify the path later reading the textures from a non-standard path. We should only check for its existence on load time
- Treat the path as a file uri always using forward slashes
- Remove relevant tests and update visualization module