### PR TITLE
Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ obj = pywavefront.Wavefront('something.obj')
 visualization.draw(obj)
 ```
 
+## Logging
+
+The default log level is `ERROR`. This is configurable including overriding the formatter.
+
+```python
+import logging
+import pywavefront
+
+pywavefront.configure_logging(
+    logging.DEBUG,
+    formatter=logging.Formatter('%(name)s-%(levelname)s: %(message)s')
+)
+```
+
 ### Example Scripts
 
 The `example` directory contains some basic examples using the `visualization` module

--- a/pywavefront/__init__.py
+++ b/pywavefront/__init__.py
@@ -31,6 +31,23 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
+import logging
+
 from pywavefront.exceptions import PywavefrontException
 from pywavefront.obj import ObjParser
 from pywavefront.wavefront import Wavefront
+
+logger = logging.getLogger("pywavefront")
+log_handler = logging.StreamHandler()
+logger.addHandler(log_handler)
+
+
+def configure_logging(level, formatter=None):
+    logger.setLevel(level)
+    log_handler.setLevel(level)
+
+    if formatter:
+        log_handler.setFormatter(formatter)
+
+
+configure_logging(logging.ERROR, logging.Formatter('%(name)s-%(levelname)s: %(message)s'))

--- a/pywavefront/material.py
+++ b/pywavefront/material.py
@@ -31,10 +31,13 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
+import logging
 import os
 
 from pywavefront.parser import Parser, auto_consume
 from pywavefront.texture import Texture
+
+logger = logging.getLogger("pywavefront")
 
 
 class Material(object):

--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -1,9 +1,12 @@
+import logging
 import os
 
 from pywavefront.exceptions import PywavefrontException
 from pywavefront.parser import Parser, auto_consume
 from pywavefront.material import Material, MaterialParser
 from pywavefront.mesh import Mesh
+
+logger = logging.getLogger("pywavefront")
 
 
 class ObjParser(Parser):

--- a/pywavefront/parser.py
+++ b/pywavefront/parser.py
@@ -39,6 +39,8 @@ import sys
 
 from pywavefront.exceptions import PywavefrontException
 
+logger = logging.getLogger("pywavefront")
+
 
 def auto_consume(func):
     """Decorator for auto consuming lines when leaving the function"""
@@ -141,7 +143,7 @@ class Parser(object):
             raise PywavefrontException("Unimplemented OBJ format statement '%s' on line '%s'"
                                        % (self.values[0], self.line.rstrip()))
         else:
-            logging.warning("Unimplemented OBJ format statement '%s' on line '%s'"
+            logger.warning("Unimplemented OBJ format statement '%s' on line '%s'"
                             % (self.values[0], self.line.rstrip()))
 
     def _build_dispatch_map(self):

--- a/pywavefront/wavefront.py
+++ b/pywavefront/wavefront.py
@@ -1,4 +1,7 @@
+import logging
 from pywavefront import ObjParser
+
+logger = logging.getLogger("pywavefront")
 
 
 class Wavefront(object):


### PR DESCRIPTION
- Simple logging setup configuring a `pywavefront` logger in the package root. It can be modified by calling `pywavefront.configure_logging()`
- The default log level is now set to `ERROR`
- Updated README with instructions on log configuration

We may want to add relevant debug logging throughout the different modules in the future. It's all there ready to use.