### PR TITLE
Switch to Python 3.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PyWavefront
 
 PyWavefront reads Wavefront 3D object files (`something.obj`, `something.obj.gz`
 and `something.mtl`) and generates interleaved vertex data for each material ready for rendering.
-Python 2.7.x or 3.6+ is supported. A simple (optional) visualization module is also
+Python 3.4+ is supported in PyWavefront 1.0.0+. An older [`python2` branch](https://github.com/greenmoss/PyWavefront/tree/python2) is still provided for Python 2.7.x, however, only fixes and no new features will be backported. A simple (optional) visualization module is also
 provided for rendering the object(s). The interleaved data can also be used by
 more modern renderers thought VBOs or VAOs.
 
@@ -166,7 +166,7 @@ All tests can be found in the `test` directory. To run the tests:
 
 ## Community
 
-Slack: [channel](https://pywavefront.slack.com/). [Email the admins](mailto:pywavefront+slack@gmail.com?subject=Please%20send%20me%20an%20invitation%20to%20the%20PyWavefront%20Slack%20channel&body=Thanks!) 
+Slack: [channel](https://pywavefront.slack.com/). [Email the admins](mailto:pywavefront+slack@gmail.com?subject=Please%20send%20me%20an%20invitation%20to%20the%20PyWavefront%20Slack%20channel&body=Thanks!)
 to request an invitation. Ensure you leave the subject line intact!
 
 ## Contributors

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = '0.4.2'
+VERSION = '1.0.0'
 
 setup(
     name='PyWavefront',
@@ -22,7 +22,6 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Natural Language :: English',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Multimedia :: Graphics :: 3D Rendering',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
This PR should finally pave the way for PR #74, especially due to the switch to Python 3.4+ in the CircleCI configuration, which is the reason why #74 is still failing.

I will rebase #74 after merging of this. (To be honest, I tried and ended up with a strange order of commits, so would probably be safer to just wait.)