### PR TITLE
Fix index errors

### DIFF
--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -396,8 +396,8 @@ class ObjParser(Parser):
                     idx = v_index,
                     pos = self.wavefront.vertices[v_index][0:3] if has_colors else self.wavefront.vertices[v_index],
                     color = self.wavefront.vertices[v_index][3:] if has_colors else (),
-                    uv = self.tex_coords[t_index] if has_vt else (),
-                    normal = self.normals[n_index] if has_vn else ()
+                    uv = self.tex_coords[t_index] if has_vt and t_index < len(self.tex_coords) else (),
+                    normal = self.normals[n_index] if has_vn and n_index < len(self.normals) else ()
                 )
 
                 yield from emit_vertex(vcurrent)

--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -183,7 +183,7 @@ class ObjParser(Parser):
 
         # Since list() also consumes StopIteration we need to sanity check the line
         # to make sure the parser advances
-        if self.values[0] == "vt":
+        if self.values and self.values[0] == "vt":
             self.next_line()
 
     def consume_texture_coordinates(self):

--- a/test/simple_extra_empty_lines.obj
+++ b/test/simple_extra_empty_lines.obj
@@ -1,0 +1,35 @@
+# Comment
+mtllib simple.mtl
+o Simple
+
+v 0.01 0.02 0.03
+v 0.04 0.05 0.06
+v 0.07 0.08 0.09
+v 0.11 0.12 0.13
+
+vt 10 11
+vt 12 13
+vt 14 15
+vt 16 17
+
+vn 20 21 22
+
+usemtl Material.simple
+f 2/3/1 1/2/1 3/1/1
+o SimpleB
+
+v 1.0 0.0 1.0
+v -1.0 0.0 1.0
+v 1.0 0.0 -1.0
+v -1.0 0.0 -1.0
+
+vt 0.0 1.0
+vt 0.0 0.0
+vt 1.0 0.0
+vt 1.0 1.0
+
+vn 0.0 1.0 -0.0
+
+usemtl Material2.simple
+
+f 6/7/2 5/6/2 7/5/2

--- a/test/simple_zero_indices.obj
+++ b/test/simple_zero_indices.obj
@@ -1,0 +1,26 @@
+# Comment
+mtllib simple.mtl
+o Simple
+v 0.01 0.02 0.03
+v 0.04 0.05 0.06
+v 0.07 0.08 0.09
+v 0.11 0.12 0.13
+vt 10 11
+vt 12 13
+vt 14 15
+vt 16 17
+vn 20 21 22
+usemtl Material.simple
+f 2/3/1 1/2/1 3/1/1
+o SimpleB
+v 1.0 0.0 1.0
+v -1.0 0.0 1.0
+v 1.0 0.0 -1.0
+v -1.0 0.0 -1.0
+vt 0.0 1.0
+vt 0.0 0.0
+vt 1.0 0.0
+vt 1.0 1.0
+vn 0.0 1.0 -0.0
+usemtl Material2.simple
+f 6/7/0 5/6/2 7/5/0

--- a/test/test_wavefront.py
+++ b/test/test_wavefront.py
@@ -70,3 +70,17 @@ class TestNoObjectNoMaterial(TestNoMaterial):
         self.mesh_names = [None]
         self.material_names = ["default0"]
         self.meshes = pywavefront.Wavefront(prepend_dir('simple_no_object_no_mtl.obj'))
+
+class TestZeroFaceNormaIndex(TestWavefront):
+    def setUp(self):
+        # reset the obj file to new file with no mtl line
+        self.mesh_names = ['Simple', 'SimpleB']
+        self.material_names = ['Material.simple', 'Material2.simple']
+        self.meshes = pywavefront.Wavefront(prepend_dir('simple_zero_indices.obj'))
+
+class TestExtraSpace(TestWavefront):
+    def setUp(self):
+        # reset the obj file to new file with no mtl line
+        self.mesh_names = ['Simple', 'SimpleB']
+        self.material_names = ['Material.simple', 'Material2.simple']
+        self.meshes = pywavefront.Wavefront(prepend_dir('simple_extra_empty_lines.obj'))


### PR DESCRIPTION
Fixed errors on a specific file (can't share sorry) probably not following the standard but Meshlab can open the file that caused these two errors.

First IndexError, may be caused by a blank line after the last `vt` 
Second IndexError, may be caused by a zero (0) normal index in many faces even though there's a large number of `vn` lines in that file.  